### PR TITLE
Method closed by parenthesis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $request = new Phly\Http\Request(
 
 // If you want to set a non-origin-form request target, set the
 // request-target explicitly:
-$request = $request->withRequestTarget((string) $uri);       // absolute-form
+$request = $request->withRequestTarget((string) $uri));       // absolute-form
 $request = $request->withRequestTarget($uri->getAuthority(); // authority-form
 $request = $request->withRequestTarget('*');                 // asterisk-form
 


### PR DESCRIPTION
correct the parenthesis in method. 
